### PR TITLE
Add property deviceCgroupRule

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -50,19 +50,20 @@ type State struct {
 
 // Browser configuration
 type Browser struct {
-	Image           interface{}       `json:"image"`
-	Port            string            `json:"port"`
-	Path            string            `json:"path"`
-	Tmpfs           map[string]string `json:"tmpfs,omitempty"`
-	Volumes         []string          `json:"volumes,omitempty"`
-	Env             []string          `json:"env,omitempty"`
-	Hosts           []string          `json:"hosts,omitempty"`
-	ShmSize         int64             `json:"shmSize,omitempty"`
-	Labels          map[string]string `json:"labels,omitempty"`
-	Sysctl          map[string]string `json:"sysctl,omitempty"`
-	Mem             string            `json:"mem,omitempty"`
-	Cpu             string            `json:"cpu,omitempty"`
-	PublishAllPorts bool              `json:"publishAllPorts,omitempty"`
+	Image            interface{}       `json:"image"`
+	Port             string            `json:"port"`
+	Path             string            `json:"path"`
+	Tmpfs            map[string]string `json:"tmpfs,omitempty"`
+	Volumes          []string          `json:"volumes,omitempty"`
+	Env              []string          `json:"env,omitempty"`
+	Hosts            []string          `json:"hosts,omitempty"`
+	ShmSize          int64             `json:"shmSize,omitempty"`
+	Labels           map[string]string `json:"labels,omitempty"`
+	Sysctl           map[string]string `json:"sysctl,omitempty"`
+	Mem              string            `json:"mem,omitempty"`
+	Cpu              string            `json:"cpu,omitempty"`
+	PublishAllPorts  bool              `json:"publishAllPorts,omitempty"`
+	DeviceCgroupRule string            `json:"deviceCgroupRule"`
 }
 
 // Versions configuration

--- a/service/docker.go
+++ b/service/docker.go
@@ -127,6 +127,7 @@ func (d *Docker) StartWithCancel() (*StartedService, error) {
 			NanoCPUs: cpu,
 		},
 		ExtraHosts: getExtraHosts(d.Service, d.Caps),
+		Cgroup:     ctr.CgroupSpec(d.Service.DeviceCgroupRule),
 	}
 	hostConfig.PublishAllPorts = d.Service.PublishAllPorts
 	if len(d.Caps.DNSServers) > 0 {


### PR DESCRIPTION
Добавил возможность указывать deviceCgroupRule для запускаемых контейнеров
Полезно для изоляции внешних устройств (если необходимо их использование при запуске сессий)

Необходимо учесть, что в таком случае при старте Selenoid необходимо выставить флаг -disable-privileged